### PR TITLE
Import only required dataset for train, test

### DIFF
--- a/test.py
+++ b/test.py
@@ -11,7 +11,6 @@ import json
 import os
 import torch
 
-import datasets
 import models
 import utils
 
@@ -58,9 +57,9 @@ def test(args):
         device = torch.device("cpu")
 
     dataset = config["data"]["dataset"]
-    if not (hasattr(datasets, dataset)):
+    if not os.path.exists(f"datasets/{dataset}.py"):
         raise ValueError(f"Unknown dataset {dataset}")
-    dataset = getattr(datasets, dataset)
+    dataset = utils.module_from_file("dataset", f"datasets/{dataset}.py")
 
     input_size = config["data"]["num_features"]
     data_path = config["data"]["data_path"]

--- a/train.py
+++ b/train.py
@@ -15,7 +15,6 @@ import sys
 import time
 import torch
 
-import datasets
 import models
 import utils
 
@@ -156,9 +155,9 @@ def train(world_rank, args):
     # setup data loaders:
     logging.info("Loading dataset ...")
     dataset = config["data"]["dataset"]
-    if not (hasattr(datasets, dataset)):
+    if not os.path.exists(f"datasets/{dataset}.py"):
         raise ValueError(f"Unknown dataset {dataset}")
-    dataset = getattr(datasets, dataset)
+    dataset = utils.module_from_file("dataset", f"datasets/{dataset}.py")
 
     input_size = config["data"]["num_features"]
     data_path = config["data"]["data_path"]

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import collections
 from dataclasses import dataclass
 import gtn
+import importlib
 import logging
 import numpy as np
 import os
@@ -15,7 +16,6 @@ import struct
 import sys
 import time
 import torch
-
 
 def data_loader(dataset, config, world_rank=0, world_size=1):
     num_samples = config["data"].get("num_samples", None)
@@ -31,6 +31,12 @@ def data_loader(dataset, config, world_rank=0, world_size=1):
         num_workers=int(world_size > 1),
     )
 
+def module_from_file(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+    return module
 
 class Subset(torch.utils.data.Subset):
     def __init__(self, dataset, indices):


### PR DESCRIPTION
When working on `iamdb`, we require `torchaudio` import now. This PR removes it.